### PR TITLE
Inspect the exit codes of the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Example output:
 + 1, black
 ```
 
+## Check exit code
+
+I'd expect the following to be something other than `0` when a difference is found (i.e. a non-zero exit code):
+```shell
+echo $?
+```
+
 ## Debug mode
 
 The following will show a full stack trace in the case of exceptions:


### PR DESCRIPTION
When a difference is found, I'd expect the following to be something other than `0`  (i.e. a non-zero exit code).

But in all modes tested so far, it doesn't do that.

We should at least show in the README how to check the exit code of the last command.