### PR TITLE
Revert "Use the profiles.yml in the current working directory"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dbt run -s simple_model
 ## Usage
 
 ```shell
-data-diff --dbt
+data-diff --dbt --dbt-profiles-dir .
 ```
 
 Example output:
@@ -91,7 +91,7 @@ echo $?
 
 The following will show a full stack trace in the case of exceptions:
 ```shell
-data-diff --dbt --debug
+data-diff --dbt --dbt-profiles-dir . --debug
 ```
 
 ## Wrap up


### PR DESCRIPTION
resolves #6

This reverts commit df32ccdaffc9c249edd6c50a1a5da38bc4c9af2a.

Long-term, we could switch back to a less verbose command if sufficient explanation is given. e.g., maybe something like this:
```
### Connecting to the warehouse
If the environment variable `DBT_PROFILES_DIR` is not in use, you can skip this section.
If it is set, then either:
1. copy the main content from `profiles.yml` in this repo into the location specified by `DBT_PROFILES_DIR`, or
2. unset it temporarily for the duration of this demo
```