### PR TITLE
Set the dbt profiles directory explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ source env/bin/activate
 
 Establish the baseline production table:
 ```shell
-dbt run -s simple_model --target prod
+dbt run -s simple_model --target prod --profiles-dir .
 ```
 
 Simulate a change to the table during development:
 ```
-dbt run -s simple_model
+dbt run -s simple_model --profiles-dir .
 ```
 
 ## Usage


### PR DESCRIPTION
resolves #6

This a follow-up to https://github.com/dbeatty10/data-diff-demo/pull/7

### Pull Request Description As Decision Record (PRD-ADR*)
Decision: list the location of the profiles directory explicitly within each command so that it "just works" for everyone (no matter what) accepting that the commands will be more verbose.

(*PRD-ADR made up on the spot, 'cause I like the concept of [MADR](https://medium.com/olzzio/the-markdown-adr-madr-template-explained-and-distilled-b67603ec95bb) and wanted to be silly today.)